### PR TITLE
fix(user-card)

### DIFF
--- a/src/components/user-card/UserCard.module.css
+++ b/src/components/user-card/UserCard.module.css
@@ -1,5 +1,6 @@
 .userCard {
   border: 1px solid var(--color-gray-400);
+  width: 100%;
 }
 
 .userCard:hover {
@@ -83,4 +84,11 @@
 
 .statsValue {
   font-size: var(--font-size-4);
+}
+
+@media screen and (min-width: 480px) {
+  .userCard {
+    width: 480px;
+    margin: 0 auto;
+  }  
 }


### PR DESCRIPTION
This PR fixes width issue for mobile devices and center the card on desktop

<img width="362" alt="Schermata 2020-04-18 alle 12 02 36" src="https://user-images.githubusercontent.com/1164569/79635656-6c36b180-8172-11ea-81ad-54e4563c5743.png">

<img width="1084" alt="Schermata 2020-04-18 alle 12 02 21" src="https://user-images.githubusercontent.com/1164569/79635658-6e990b80-8172-11ea-8046-abe988e8db19.png">
