### PR TITLE
Use CSS grid instead of flex for trending developers layout section

### DIFF
--- a/src/components/trending-developers/TrendingDevelopers.module.css
+++ b/src/components/trending-developers/TrendingDevelopers.module.css
@@ -13,8 +13,8 @@
 }
 
 .list {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   list-style: none;
   margin: 0;
   padding: 0;
@@ -22,13 +22,17 @@
 
 @media screen and (min-width: 480px) {
   .list {
-    flex-direction: row;
+    grid-template-columns: repeat(3, 1fr)
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .list {
+    grid-template-columns: repeat(4, 1fr)
   }
 }
 
 .item {
-  flex: 1 0 50%;
-  max-width: 50%;
   padding: 0.5rem 0;
   text-align: center;
 }
@@ -36,7 +40,6 @@
 @media screen and (min-width: 480px) {
   .item {
     padding: 1rem;
-    flex: 1;
     text-align: left;
   }
 }


### PR DESCRIPTION
### DESCRIPTION

Use CSS grid instead of flex for trending developers layout section.

**Flexbox:**

![Annotazione 2020-05-15 204905](https://user-images.githubusercontent.com/1985555/82086413-c897dd00-96ee-11ea-85b6-834cad66f641.jpg)

**CSS grid**

![Annotazione 2020-05-15 204922](https://user-images.githubusercontent.com/1985555/82086433-cd5c9100-96ee-11ea-93bc-00f3f907f7df.jpg)

